### PR TITLE
Fixing error in the re-entrancy section

### DIFF
--- a/src/content/developers/docs/security/index.md
+++ b/src/content/developers/docs/security/index.md
@@ -101,13 +101,13 @@ Calling Attacker.beginAttack() will start a cycle that looks something like:
 0.) Attacker.beginAttack() deposits 1 ETH into Victim
 
   1.) Attacker -> Victim.withdraw()
-  1.) Victim reads balanceOf[msg.sender]
+  1.) Victim reads balances[msg.sender]
   1.) Victim sends ETH to Attacker (which executes default function)
     2.) Attacker -> Victim.withdraw()
-    2.) Victim reads balanceOf[msg.sender]
+    2.) Victim reads balances[msg.sender]
     2.) Victim sends ETH to Attacker (which executes default function)
       3.) Attacker -> Victim.withdraw()
-      3.) Victim reads balanceOf[msg.sender]
+      3.) Victim reads balances[msg.sender]
       3.) Victim sends ETH to Attacker (which executes default function)
         4.) Attacker no longer has enough gas, returns without calling again
       3.) balances[msg.sender] = 0;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

The name of the mapping in the Victim contract is balances, but in the cycle description when the Attacker calls Victim.withdraw() the Victim should read balances[msg.sender] instead of balanceOf[msg.sender]


## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
